### PR TITLE
Differentiate completeness based on record type

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ The values added to expand an incomplete record are the lower bounds
 for the appropriate fields, so 1 for month or day, 0 for any time
 field.
 
-`jam:is_complete/1` can be used to test a date, time, or datetime
-structure for completeness.
+`jam:is_complete/1` can be used to test a datetime structure (compiled
+or not) for completeness. Use `jam:is_complete_date/1` or
+`jam:is_complete_time/1` for dates and times outside a datetime
+structure.
 
-It may be useful to adjust an incomplete date/time via
+It may be useful to adjust a compiled, incomplete date/time via
 `jam:increment/2`. This identifies the least significant populated
 value and adds an integer value. One example is strictly greater-than
 comparisons in Riak's timeseries support.

--- a/test/iso8601_tests.erl
+++ b/test/iso8601_tests.erl
@@ -95,7 +95,7 @@
          "2016"
         ]).
 
--define(COMPLETE_STRINGS,
+-define(COMPLETE_DATETIMES,
         [
          "2016-06-23T14:10:33",
          "2016-06-23T14:10:59",
@@ -105,17 +105,40 @@
          "2016-06-23T00:00:05.023",
          "2016-06-23T00:00:05.2",
          "2016-06-23T00:00.2",
-         "2016-06-23T00.2",
-         "14:10:59",
-         "2016-06-23"
+         "2016-06-23T00.2"
         ]).
 
--define(INCOMPLETE_STRINGS,
+-define(COMPLETE_DATES,
+        [
+         "2016-06-23",
+         "2016-257"
+        ]).
+
+-define(COMPLETE_TIMES,
+        [
+         "14:10:59",
+         "14:10.95",
+         "14.22",
+         "14.22Z"
+        ]).
+
+
+-define(INCOMPLETE_DATETIMES,
         [
          "2016-06-23T14:10",
-         "2016-06-23T14:10+05:00",
+         "2016-06-23T14:10+05:00"
+        ]).
+
+-define(INCOMPLETE_DATES,
+        [
          "2016-06",
          "2016"
+        ]).
+
+-define(INCOMPLETE_TIMES,
+        [
+         "14:10",
+         "14"
         ]).
 
 -define(INVALID_EXTENDED_STRINGS,
@@ -152,10 +175,23 @@
 
 completeness_test_() ->
     lists:map(fun(Str) -> ?_assert(jam:is_complete(jam:compile(jam_iso8601:parse(Str)))) end,
-              ?COMPLETE_STRINGS)
+              ?COMPLETE_DATETIMES)
+        ++
+    lists:map(fun(Str) -> ?_assert(jam:is_complete_date(jam:compile(jam_iso8601:parse(Str)))) end,
+              ?COMPLETE_DATES)
+        ++
+    lists:map(fun(Str) -> ?_assert(jam:is_complete_time(jam:compile(jam_iso8601:parse(Str)))) end,
+              ?COMPLETE_TIMES)
         ++
     lists:map(fun(Str) -> ?_assert(not jam:is_complete(jam:compile(jam_iso8601:parse(Str)))) end,
-              ?INCOMPLETE_STRINGS).
+              ?INCOMPLETE_DATETIMES)
+        ++
+    lists:map(fun(Str) -> ?_assert(not jam:is_complete_date(jam:compile(jam_iso8601:parse(Str)))) end,
+              ?INCOMPLETE_DATES)
+        ++
+    lists:map(fun(Str) -> ?_assert(not jam:is_complete_time(jam:compile(jam_iso8601:parse(Str)))) end,
+              ?INCOMPLETE_TIMES).
+
 
 via_epoch_test_() ->
     %% The precision values passed to `to_epoch' and `from_epoch' must


### PR DESCRIPTION
When `jam:is_complete/1` was allowed to take datetime, time, or date records as arguments, it could lead to unexpected behaviors, such as parsing a date in a context that expected a date+time and then verifying its completeness (incorrectly).

Formerly:
`true = jam:is_complete(jam:compile(jam_iso8601:parse("2016-08-01")))`

Now:
`false = jam:is_complete(jam:compile(jam_iso8601:parse("2016-08-01")))`

But:
`true = jam:is_complete_date(jam:compile(jam_iso8601:parse("2016-08-01")))`